### PR TITLE
Add LoadLibraryW hook to fix DLL loading issues

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -28,6 +28,7 @@ use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
 use windows_sys::Win32::Storage::FileSystem::{
     CreateFileW, FindClose, FindFileHandle, FindFirstFileExW, FindFirstFileW, FindNextFileW, GetFileAttributesExW, GetFileAttributesW, NtCreateFile, FILE_ATTRIBUTE_DIRECTORY, FILE_CREATION_DISPOSITION, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_MODE, FINDEX_INFO_LEVELS, FINDEX_SEARCH_OPS, FIND_FIRST_EX_FLAGS, GET_FILEEX_INFO_LEVELS, NT_CREATE_FILE_DISPOSITION, WIN32_FIND_DATAW
 };
+use windows_sys::Win32::System::LibraryLoader::LoadLibraryW;
 use windows_sys::Win32::System::WindowsProgramming::{
     IO_STATUS_BLOCK,
     IO_STATUS_BLOCK_0,
@@ -88,6 +89,8 @@ static_detour! {
     ) -> BOOL;
 
     pub static FindClose_Detour: unsafe extern "system" fn(HANDLE) -> BOOL;
+
+    pub static LoadLibraryW_Detour: unsafe extern "system" fn(PCWSTR) -> HMODULE;
 }
 
 pub unsafe fn enable_hooks() -> Result<(), Box<dyn Error>> {
@@ -134,6 +137,11 @@ pub unsafe fn enable_hooks() -> Result<(), Box<dyn Error>> {
     FindFirstFileExW_Detour.initialize(FindFirstFileExW, |a, b, c, d, e, f| unsafe {
         findfirstfileexw_detour(a, b, c, d, e, f)
     })?.enable()?;
+
+    LoadLibraryW_Detour.initialize(LoadLibraryW, |lpfilename| unsafe {
+        loadlibraryw_detour(lpfilename)
+    })?.enable()?;
+    
 
     Ok(())
 }
@@ -215,7 +223,7 @@ pub unsafe extern "system" fn ntcreatefile_detour(
     let original_path = PathBuf::from(original_path_str.to_string().unwrap());
     let new_path = NormalizedPath::new(&original_path);
     let new_path = utils::reroot_path(&new_path).unwrap_or(new_path.0);
-
+    
     debug!("[ntcreatefile_detour] {:?} to {:?}", original_path, new_path);
 
     // Update the Length property in the UNICODE_STRING struct with the new length of the path.
@@ -363,4 +371,17 @@ unsafe extern "system" fn findfirstfileexw_detour(
         search_filter,
         additional_flags
     )
+}
+
+
+unsafe extern "system" fn loadlibraryw_detour(lpfilename: PCWSTR) -> HMODULE {
+    let path = utils::pcwstr_to_path(lpfilename);
+    let new_path = utils::reroot_path(&path).unwrap_or(path.0.clone());
+    debug!("[loadlibraryw_detour] {:?} to {:?}", path, new_path);
+
+    let wide_path = utils::path_to_widestring(&new_path);
+
+    let raw_path = wide_path.as_ptr();
+
+    LoadLibraryW_Detour.call(raw_path)
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -22,7 +22,8 @@ use windows_sys::Win32::Foundation::{
     HANDLE, 
     MAX_PATH, 
     NTSTATUS, 
-    UNICODE_STRING
+    UNICODE_STRING,
+    HMODULE
 };
 use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
 use windows_sys::Win32::Storage::FileSystem::{


### PR DESCRIPTION

This PR adds a hook for the LoadLibraryW function to address issues I've encountered with loading custom DLLs.

- Adding a static detour for LoadLibraryW
- Implementing a loadlibraryw_detour function
- Initializing the new hook in the enable_hooks function

These changes allow the shimloader to intercept and potentially redirect LoadLibraryW calls, which should resolve issues where custom DLLs were not being loaded correctly.

UE4SS uses LoadLibraryW for loading C++ mods. Without this hook, the shimloader was unable to properly intercept and redirect these calls, leading to failures in loading custom DLLs. This implementation is currently the only way I was able to get custom DLLs working correctly with UE4SS in this environment. If there are any other solutions please share.

Testing:
- Tested with Voices of the Void 0.8e
- Verified that custom DLLs are now being loaded correctly
- Checked that other mod files (e.g., Lua scripts) continue to load as expected
- Mod tested (local import r2modman):  [r2.zip](https://github.com/user-attachments/files/16941439/r2.zip)
- unreal-shimloader launched with args:
> --mod-dir "C:\Users\user\AppData\Roaming\r2modmanPlus-local\VotV\profiles\Default\shimloader\mod" --pak-dir "C:\Users\user\AppData\Roaming\r2modmanPlus-local\VotV\profiles\Default\shimloader\pak" --cfg-dir "C:\Users\user\AppData\Roaming\r2modmanPlus-local\VotV\profiles\Default\shimloader\cfg"

Without LoadLibraryW hook:
![365439870-43ca42d4-1d3a-4115-8871-97de648b9009](https://github.com/user-attachments/assets/72529195-0c5c-439d-be5e-0a94a462feb0)


With LoadLibraryW hook:
![image](https://github.com/user-attachments/assets/c86b66da-294b-4415-968d-bd15019a6212)


Related issues: #4 

Let me know if you need any additional information or if you'd like me to make any changes to this PR.