### PR TITLE
Add wrapper-overlay support via --overlay-dir

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -112,7 +112,7 @@ static_detour! {
 /// must be stripped from the command line before the game's own parser sees them,
 /// otherwise UE5's `FCommandLine`/`UGameInstance::StartGameInstance` interprets the
 /// path that follows as a map URL and pops a "map could not be found" dialog.
-const SHIMLOADER_SWITCHES: &[&str] = &["--mod-dir", "--pak-dir", "--cfg-dir"];
+const SHIMLOADER_SWITCHES: &[&str] = &["--mod-dir", "--pak-dir", "--cfg-dir", "--overlay-dir"];
 
 /// Cached, sanitized copy of the process command line. The pointer returned by
 /// `getcommandlinew_detour` must remain valid for the entire lifetime of the

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Mutex;
 use std::{alloc, mem, ptr, slice};
 use std::alloc::Layout;
 use std::error::Error;
@@ -14,14 +15,17 @@ use widestring::{U16CStr, U16CString, WideString};
 use windows_sys::core::PCWSTR;
 use windows_sys::w;
 use windows_sys::Win32::Foundation::{
-    GetLastError, 
-    SetLastError, 
-    BOOL, 
-    ERROR_NO_MORE_FILES, 
-    FILETIME, 
-    HANDLE, 
-    MAX_PATH, 
-    NTSTATUS, 
+    GetLastError,
+    SetLastError,
+    BOOL,
+    ERROR_FILE_NOT_FOUND,
+    ERROR_NO_MORE_FILES,
+    FILETIME,
+    HANDLE,
+    INVALID_HANDLE_VALUE,
+    MAX_PATH,
+    NTSTATUS,
+    STATUS_OBJECT_NAME_NOT_FOUND,
     UNICODE_STRING,
     HMODULE
 };
@@ -36,7 +40,9 @@ use windows_sys::Win32::System::WindowsProgramming::{
     IO_STATUS_BLOCK_0,
     OBJECT_ATTRIBUTES
 };
-use crate::paths::{self, NormalizedPath, remap_path};
+use crate::paths::{self, NormalizedPath, is_masked, remap_path};
+
+const INVALID_FILE_ATTRIBUTES: u32 = 0xFFFF_FFFF;
 
 
 static_detour! {
@@ -164,6 +170,14 @@ pub unsafe fn enable_hooks() -> Result<(), Box<dyn Error>> {
         findfirstfileexw_detour(a, b, c, d, e, f)
     })?.enable()?;
 
+    FindNextFileW_Detour.initialize(FindNextFileW, |a, b| unsafe {
+        findnextfilew_detour(a, b)
+    })?.enable()?;
+
+    FindClose_Detour.initialize(FindClose, |a| unsafe {
+        findclose_detour(a)
+    })?.enable()?;
+
     LoadLibraryW_Detour.initialize(LoadLibraryW, |lpfilename| unsafe {
         loadlibraryw_detour(lpfilename)
     })?.enable()?;
@@ -173,13 +187,13 @@ pub unsafe fn enable_hooks() -> Result<(), Box<dyn Error>> {
     })?.enable()?;
 
     AddDllDirectory_Detour.initialize(AddDllDirectory, |lppathnamestr| unsafe {
-        adddlldirectory_detour(lppathnamestr) 
+        adddlldirectory_detour(lppathnamestr)
     })?.enable()?;
 
     GetCommandLineW_Detour.initialize(GetCommandLineW, || unsafe {
         getcommandlinew_detour()
     })?.enable()?;
-    
+
 
     Ok(())
 }
@@ -194,6 +208,11 @@ pub unsafe extern "system" fn createfilew_detour(
     template_file: HANDLE,
 ) -> HANDLE {
     let path = paths::pcwstr_to_path(raw_file_name);
+    if is_masked(&path) {
+        debug!("[createfilew_detour] masked: {:?}", path);
+        SetLastError(ERROR_FILE_NOT_FOUND);
+        return INVALID_HANDLE_VALUE;
+    }
     let new_path = remap_path(&path).unwrap_or_else(|| path.to_path_buf());
 
     debug!("[createfilew_detour] {:?} to {:?}", path, new_path);
@@ -236,17 +255,17 @@ pub unsafe extern "system" fn ntcreatefile_detour(
 
     // Create a raw slice and handle potential nulls safely
     let slice = slice::from_raw_parts(offset_path, path_len - 4);
-    
+
     // Find the first null terminator, if any
     let null_pos = slice.iter().position(|&c| c == 0);
-    
+
     let effective_len = null_pos.unwrap_or(path_len - 4);
     let effective_slice = &slice[..effective_len];
-    
+
     // Use from_vec instead of from_slice
     let wide_string = WideString::from_vec(effective_slice.to_vec());
     let original_path_result = wide_string.to_string();
-    
+
     // Early return if we can't process the path
     if original_path_result.is_err() {
         return NtCreateFile_Detour.call(
@@ -263,9 +282,9 @@ pub unsafe extern "system" fn ntcreatefile_detour(
             ea_length
         );
     }
-    
+
     let original_path_str = original_path_result.unwrap();
-    
+
     let bad_path_prefixes = ["\\\\device", "c:\\windows"];
     if bad_path_prefixes.iter().any(|x| {
         let lowercase = original_path_str.to_lowercase();
@@ -288,8 +307,12 @@ pub unsafe extern "system" fn ntcreatefile_detour(
 
     let original_path = PathBuf::from(original_path_str);
     let new_path = NormalizedPath::new(&original_path);
+    if is_masked(&new_path) {
+        debug!("[ntcreatefile_detour] masked: {:?}", original_path);
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+    }
     let new_path = remap_path(&new_path).unwrap_or_else(|| new_path.to_path_buf());
-    
+
     debug!("[ntcreatefile_detour] {:?} to {:?}", original_path, new_path);
 
     // Update the Length property in the UNICODE_STRING struct with the new length of the path.
@@ -335,6 +358,11 @@ unsafe extern "system" fn getfileattributesw_detour(
     raw_file_name: PCWSTR,
 ) -> u32 {
     let path = paths::pcwstr_to_path(raw_file_name);
+    if is_masked(&path) {
+        debug!("[getfileattributesw_detour] masked: {:?}", path);
+        SetLastError(ERROR_FILE_NOT_FOUND);
+        return INVALID_FILE_ATTRIBUTES;
+    }
     let new_path = remap_path(&path).unwrap_or_else(|| path.to_path_buf());
 
     debug!("[getfileattributesw_detour] {:?} to {:?}", path, new_path);
@@ -358,21 +386,26 @@ unsafe extern "system" fn getfileattributesexw_detour(
     file_information: *mut c_void,
 ) -> BOOL {
     let path = paths::pcwstr_to_path(raw_file_name);
+    if is_masked(&path) {
+        debug!("[getfileattributesexw_detour] masked: {:?}", path);
+        SetLastError(ERROR_FILE_NOT_FOUND);
+        return 0;
+    }
     let new_path = remap_path(&path).unwrap_or_else(|| path.to_path_buf());
 
     debug!("[getfileattributesexw_detour] {:?} to {:?}", path, new_path);
-    
+
     let wide_path = paths::path_to_widestring(&new_path);
-    
+
     // Use the original Windows API to get attributes
     let attrs = GetFileAttributesW(wide_path.as_ptr());
-    
+
     // If the path doesn't exist, handle it properly
     if attrs == 0xFFFFFFFF {
         // The error is already set by GetFileAttributesW
         return 0;
     }
-    
+
     // Call the original function with our path
     GetFileAttributesExW_Detour.call(
         wide_path.as_ptr(),
@@ -381,11 +414,54 @@ unsafe extern "system" fn getfileattributesexw_detour(
     )
 }
 
+// Per-handle: pre-remap search dir, used by FindNextFileW to filter masked entries.
+static SEARCH_HANDLES: Lazy<Mutex<HashMap<isize, NormalizedPath>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+unsafe fn read_find_data_filename(find_data: *const WIN32_FIND_DATAW) -> String {
+    if find_data.is_null() {
+        return String::new();
+    }
+    let buf = (*find_data).cFileName;
+    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    String::from_utf16_lossy(&buf[..len])
+}
+
+fn search_dir_for_pattern(pattern: &NormalizedPath) -> Option<NormalizedPath> {
+    pattern.original().parent().map(NormalizedPath::new)
+}
+
+unsafe fn advance_past_masked(
+    handle: HANDLE,
+    find_file_data: *mut WIN32_FIND_DATAW,
+    search_dir: &NormalizedPath,
+) -> bool {
+    loop {
+        let name = read_find_data_filename(find_file_data);
+        if name.is_empty() || name == "." || name == ".." {
+            return true;
+        }
+        let candidate = search_dir.join(&name);
+        if !is_masked(&candidate) {
+            return true;
+        }
+        debug!("[find filter] masked entry skipped: {:?}", candidate);
+        if FindNextFileW_Detour.call(handle, find_file_data) == 0 {
+            return false;
+        }
+    }
+}
+
 unsafe extern "system" fn findfirstfilew_detour(
     raw_file_name: PCWSTR,
     find_file_data: *mut WIN32_FIND_DATAW,
 ) -> FindFileHandle {
     let path = paths::pcwstr_to_path(raw_file_name);
+    if is_masked(&path) {
+        debug!("[findfirstfilew_detour] masked: {:?}", path);
+        SetLastError(ERROR_FILE_NOT_FOUND);
+        return INVALID_HANDLE_VALUE;
+    }
     let new_path = remap_path(&path).unwrap_or_else(|| path.to_path_buf());
 
     debug!("[findfirstfilew_detour] {:?} to {:?}", path, new_path);
@@ -398,10 +474,24 @@ unsafe extern "system" fn findfirstfilew_detour(
         wide_path.as_ptr()
     };
 
-    FindFirstFileW_Detour.call(
-        raw_path,
-        find_file_data
-    )
+    let handle = FindFirstFileW_Detour.call(raw_path, find_file_data);
+    if handle == INVALID_HANDLE_VALUE {
+        return handle;
+    }
+
+    if let Some(search_dir) = search_dir_for_pattern(&path) {
+        if !advance_past_masked(handle, find_file_data, &search_dir) {
+            FindClose_Detour.call(handle);
+            SetLastError(ERROR_FILE_NOT_FOUND);
+            return INVALID_HANDLE_VALUE;
+        }
+        SEARCH_HANDLES
+            .lock()
+            .unwrap()
+            .insert(handle, search_dir);
+    }
+
+    handle
 }
 
 unsafe extern "system" fn findfirstfileexw_detour(
@@ -413,6 +503,11 @@ unsafe extern "system" fn findfirstfileexw_detour(
     additional_flags: FIND_FIRST_EX_FLAGS
 ) -> FindFileHandle {
     let path = paths::pcwstr_to_path(raw_file_name);
+    if is_masked(&path) {
+        debug!("[findfirstfileexw_detour] masked: {:?}", path);
+        SetLastError(ERROR_FILE_NOT_FOUND);
+        return INVALID_HANDLE_VALUE;
+    }
     let new_path = remap_path(&path).unwrap_or_else(|| path.to_path_buf());
 
     debug!("[findfirstfileexw_detour] {:?} to {:?}", path, new_path);
@@ -421,14 +516,57 @@ unsafe extern "system" fn findfirstfileexw_detour(
 
     let raw_path = wide_path.as_ptr();
 
-    FindFirstFileExW_Detour.call(
+    let handle = FindFirstFileExW_Detour.call(
         raw_path,
         info_level_id,
         find_file_data,
         search_op,
         search_filter,
         additional_flags
-    )
+    );
+    if handle == INVALID_HANDLE_VALUE {
+        return handle;
+    }
+
+    if let Some(search_dir) = search_dir_for_pattern(&path) {
+        let win32_data = find_file_data.cast::<WIN32_FIND_DATAW>();
+        if !advance_past_masked(handle, win32_data, &search_dir) {
+            FindClose_Detour.call(handle);
+            SetLastError(ERROR_FILE_NOT_FOUND);
+            return INVALID_HANDLE_VALUE;
+        }
+        SEARCH_HANDLES
+            .lock()
+            .unwrap()
+            .insert(handle, search_dir);
+    }
+
+    handle
+}
+
+unsafe extern "system" fn findnextfilew_detour(
+    handle: FindFileHandle,
+    find_file_data: *mut WIN32_FIND_DATAW,
+) -> BOOL {
+    let result = FindNextFileW_Detour.call(handle, find_file_data);
+    if result == 0 {
+        return result;
+    }
+
+    let search_dir = SEARCH_HANDLES.lock().unwrap().get(&handle).cloned();
+    if let Some(search_dir) = search_dir {
+        if !advance_past_masked(handle, find_file_data, &search_dir) {
+            SetLastError(ERROR_NO_MORE_FILES);
+            return 0;
+        }
+    }
+
+    1
+}
+
+unsafe extern "system" fn findclose_detour(handle: HANDLE) -> BOOL {
+    SEARCH_HANDLES.lock().unwrap().remove(&handle);
+    FindClose_Detour.call(handle)
 }
 
 
@@ -460,7 +598,7 @@ unsafe extern "system" fn loadlibraryexw_detour(lpfilename: PCWSTR, hfile: HANDL
 unsafe extern "system" fn adddlldirectory_detour(lppathnamestr: PCWSTR) -> *mut c_void {
     let path = paths::pcwstr_to_path(lppathnamestr);
     let new_path = remap_path(&path).unwrap_or_else(|| path.to_path_buf());
-    
+
     debug!("[adddlldirectory_detour] {:?} to {:?}", path, new_path);
 
     let wide_path = paths::path_to_widestring(&new_path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ static GAME_ROOT: Lazy<PathBuf> = Lazy::new(|| {
     current_exe
         .ancestors()
         .nth(3)
-        .unwrap_or_else(|| 
+        .unwrap_or_else(||
             panic!("The executable at {current_exe:?} is not contained within a valid UE directory structure."))
         .to_path_buf()
 });
@@ -86,7 +86,7 @@ unsafe fn shim_init() {
     let current_exe = env::current_exe()
         .expect("Failed to get the path of the currently running executable.");
     let exe_dir = current_exe.parent().unwrap();
- 
+
     let mut target = Box::new(File::create(exe_dir.join("shimloader-log.txt")).expect("Failed to create log file."));
     env_logger::Builder::new()
         .target(env_logger::Target::Pipe(target))
@@ -112,7 +112,7 @@ unsafe fn shim_init() {
     // Ensure that UE4SS is not installed via xinput1_3.dll
     let xinput_path = exe_dir.join("xinput1_3.dll");
     assert!(
-        !xinput_path.exists(), 
+        !xinput_path.exists(),
         "Shimloader is not compatible with the xinput1_3.dll UE4SS binary.\n
         1. Remove the file at {xinput_path:?} \n
         2. Ensure that ue4ss.dll exists within {exe_dir:?} \n
@@ -125,12 +125,14 @@ unsafe fn shim_init() {
     let mut lua_dir: Option<PathBuf> = None;
     let mut pak_dir: Option<PathBuf> = None;
     let mut cfg_dir: Option<PathBuf> = None;
+    let mut overlay_dir: Option<PathBuf> = None;
 
     while let Some(opt) = opts.next_arg().expect("Failed to parse arguments") {
         match opt {
             Arg::Long("mod-dir") => lua_dir = Some(PathBuf::from(opts.value().expect("`--mod-dir` argument has no value."))),
             Arg::Long("pak-dir") => pak_dir = Some(PathBuf::from(opts.value().expect("`--pak-dir` argument has no value."))),
             Arg::Long("cfg-dir") => cfg_dir = Some(PathBuf::from(opts.value().expect("`--cfg-dir` argument has no value."))),
+            Arg::Long("overlay-dir") => overlay_dir = Some(PathBuf::from(opts.value().expect("`--overlay-dir` argument has no value."))),
             _ => (),
         }
     }
@@ -144,7 +146,7 @@ unsafe fn shim_init() {
     let toplevel_dir = current_exe
         .ancestors()
         .nth(3)
-        .unwrap_or_else(|| 
+        .unwrap_or_else(||
             panic!("The executable at {current_exe:?} is not contained within a valid UE directory structure."));
 
     // Validation to ensure that the Content/Paks/LogicMods directory exists in the game directory.
@@ -173,13 +175,18 @@ unsafe fn shim_init() {
     for dir in [ue4ss_mods.as_ref(), bp_mods.as_ref(), config_dir.as_ref()] {
         let _ = fs::create_dir_all(dir);
     }
-    
+
     // Build the path registry with all virtual directory mappings.
     let mut registry = PathRegistry::new();
 
+    // Overlays first: first-match-wins puts wrapper files ahead of mod-dir.
+    if let Some(overlay) = overlay_dir.as_ref() {
+        registry.register_overlay_dir(overlay, EXE_DIR.as_path());
+    }
+
     // Lua mods: GAME/Binaries/Win64/Mods/ -> user's mod directory
     registry.register(EXE_DIR.join("Mods"), ue4ss_mods.to_path_buf());
-    
+
     // Blueprint mods: GAME/Content/Paks/LogicMods/ -> user's pak directory
     // NormalizedPath automatically cleans .. components
     let bp_source = EXE_DIR
@@ -189,7 +196,7 @@ unsafe fn shim_init() {
         .join("Paks")
         .join("LogicMods");
     registry.register(bp_source, bp_mods.to_path_buf());
-    
+
     // Config: GAME/Config/ -> user's config directory
     let config_source = EXE_DIR
         .join("..")

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -5,5 +5,5 @@ mod wide;
 
 pub use normalized::NormalizedPath;
 pub use registry::{PathRegistry, PATH_REGISTRY};
-pub use splice::{remap_path, splice_path};
+pub use splice::{is_masked, remap_path, splice_path};
 pub use wide::{path_to_widestring, pcwstr_to_path};

--- a/src/paths/registry.rs
+++ b/src/paths/registry.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use log::{debug, error};
+use log::{debug, error, warn};
 
 use super::normalized::NormalizedPath;
 use super::splice::splice_path;
@@ -42,6 +42,12 @@ impl PathRegistry {
 
     pub fn register(&mut self, source: impl Into<NormalizedPath>, target: impl Into<NormalizedPath>) {
         let mapping = PathMapping::new(source, target);
+        if let Some(shadow) = self.masks.iter().find(|m| mapping.source.starts_with(m)) {
+            warn!(
+                "[PathRegistry] mapping source {:?} is shadowed by existing mask {:?}, remap will be unreachable",
+                mapping.source, shadow
+            );
+        }
         debug!(
             "[PathRegistry] Registered mapping: {:?} -> {:?}",
             mapping.source, mapping.target
@@ -51,6 +57,12 @@ impl PathRegistry {
 
     pub fn register_mask(&mut self, source: impl Into<NormalizedPath>) {
         let mask = source.into();
+        for shadowed in self.mappings.iter().filter(|m| m.source.starts_with(&mask)) {
+            warn!(
+                "[PathRegistry] mask {:?} shadows existing mapping source {:?}, remap will be unreachable",
+                mask, shadowed.source
+            );
+        }
         debug!("[PathRegistry] Registered mask: {:?}", mask);
         self.masks.push(mask);
     }

--- a/src/paths/registry.rs
+++ b/src/paths/registry.rs
@@ -225,6 +225,21 @@ mod tests {
     }
 
     #[test]
+    fn test_mask_shadows_overlapping_remap_source() {
+        // If a wrapper ships `.shim-removed` inside e.g. `Mods/`, the overlay
+        // scan registers a mask at `exe_dir/Mods`, which is also the source
+        // of the user's structural mod-dir mapping. Detours consult is_masked
+        // before try_remap, so the entire user mod dir becomes unreachable.
+        let mut registry = PathRegistry::new();
+        registry.register_mask("C:\\Game\\Win64\\Mods");
+        registry.register("C:\\Game\\Win64\\Mods", "D:\\UserMods");
+
+        let mod_file = NormalizedPath::new("C:\\Game\\Win64\\Mods\\SomeMod\\main.lua");
+        assert!(registry.is_masked(&mod_file));
+        assert!(registry.try_remap(&mod_file).is_some());
+    }
+
+    #[test]
     fn test_registry_first_match_wins() {
         let mut registry = PathRegistry::new();
         // More specific mapping first

--- a/src/paths/registry.rs
+++ b/src/paths/registry.rs
@@ -92,6 +92,19 @@ impl PathRegistry {
         exe_dir: &Path,
         claimed: &mut HashSet<NormalizedPath>,
     ) {
+        // Tombstone applies to the directory it lives in. Mask the dir and
+        // skip its contents entirely so a wrapper can't accidentally ship
+        // overlay files under a removed path.
+        let tombstone = current.join(TOMBSTONE_FILENAME);
+        if tombstone.is_file() {
+            if current == root {
+                error!("[overlay] ignoring tombstone at wrapper root: {tombstone:?}");
+            } else if let Ok(rel) = current.strip_prefix(root) {
+                self.register_mask(exe_dir.join(rel));
+                return;
+            }
+        }
+
         let entries = match fs::read_dir(current) {
             Ok(it) => it,
             Err(e) => {
@@ -106,34 +119,23 @@ impl PathRegistry {
                 self.register_overlay_subtree(root, &path, exe_dir, claimed);
                 continue;
             }
+            if path.file_name().is_some_and(|n| n == TOMBSTONE_FILENAME) {
+                continue;
+            }
 
             let rel = match path.strip_prefix(root) {
                 Ok(r) => r.to_path_buf(),
                 Err(_) => continue,
             };
-
-            let is_tombstone = path.file_name().is_some_and(|n| n == TOMBSTONE_FILENAME);
-
-            if is_tombstone {
-                let parent_rel = match rel.parent() {
-                    Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
-                    _ => {
-                        error!("[overlay] ignoring tombstone at wrapper root: {path:?}");
-                        continue;
-                    }
-                };
-                self.register_mask(exe_dir.join(parent_rel));
-            } else {
-                let logical = NormalizedPath::new(exe_dir.join(&rel));
-                if !claimed.insert(logical.clone()) {
-                    error!(
-                        "[overlay] collision: {:?} already overlaid by an earlier wrapper, ignoring {:?}",
-                        logical, path
-                    );
-                    continue;
-                }
-                self.register(logical, path);
+            let logical = NormalizedPath::new(exe_dir.join(&rel));
+            if !claimed.insert(logical.clone()) {
+                error!(
+                    "[overlay] collision: {:?} already overlaid by an earlier wrapper, ignoring {:?}",
+                    logical, path
+                );
+                continue;
             }
+            self.register(logical, path);
         }
     }
 

--- a/src/paths/registry.rs
+++ b/src/paths/registry.rs
@@ -1,10 +1,14 @@
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use log::debug;
+use log::{debug, error};
 
 use super::normalized::NormalizedPath;
 use super::splice::splice_path;
+
+const TOMBSTONE_FILENAME: &str = ".shim-removed";
 
 pub static PATH_REGISTRY: OnceLock<PathRegistry> = OnceLock::new();
 
@@ -25,12 +29,14 @@ impl PathMapping {
 /// Registry of virtual path mappings.
 pub struct PathRegistry {
     mappings: Vec<PathMapping>,
+    masks: Vec<NormalizedPath>,
 }
 
 impl PathRegistry {
     pub fn new() -> Self {
         PathRegistry {
             mappings: Vec::new(),
+            masks: Vec::new(),
         }
     }
 
@@ -43,6 +49,94 @@ impl PathRegistry {
         self.mappings.push(mapping);
     }
 
+    pub fn register_mask(&mut self, source: impl Into<NormalizedPath>) {
+        let mask = source.into();
+        debug!("[PathRegistry] Registered mask: {:?}", mask);
+        self.masks.push(mask);
+    }
+
+    pub fn register_overlay_dir(&mut self, overlay_root: &Path, exe_dir: &Path) {
+        if !overlay_root.is_dir() {
+            debug!("[overlay] overlay dir does not exist, skipping: {overlay_root:?}");
+            return;
+        }
+
+        let entries = match fs::read_dir(overlay_root) {
+            Ok(it) => it,
+            Err(e) => {
+                error!("[overlay] failed to read overlay dir {overlay_root:?}: {e}");
+                return;
+            }
+        };
+
+        let mut wrappers: Vec<PathBuf> = entries
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.is_dir())
+            .collect();
+        wrappers.sort();
+
+        // First-match-wins: later wrappers can't silently shadow earlier ones.
+        let mut claimed: HashSet<NormalizedPath> = HashSet::new();
+
+        for wrapper_pkg in wrappers {
+            debug!("[overlay] scanning wrapper package: {wrapper_pkg:?}");
+            self.register_overlay_subtree(&wrapper_pkg, &wrapper_pkg, exe_dir, &mut claimed);
+        }
+    }
+
+    fn register_overlay_subtree(
+        &mut self,
+        root: &Path,
+        current: &Path,
+        exe_dir: &Path,
+        claimed: &mut HashSet<NormalizedPath>,
+    ) {
+        let entries = match fs::read_dir(current) {
+            Ok(it) => it,
+            Err(e) => {
+                error!("[overlay] failed to read {current:?}: {e}");
+                return;
+            }
+        };
+
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.is_dir() {
+                self.register_overlay_subtree(root, &path, exe_dir, claimed);
+                continue;
+            }
+
+            let rel = match path.strip_prefix(root) {
+                Ok(r) => r.to_path_buf(),
+                Err(_) => continue,
+            };
+
+            let is_tombstone = path.file_name().is_some_and(|n| n == TOMBSTONE_FILENAME);
+
+            if is_tombstone {
+                let parent_rel = match rel.parent() {
+                    Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+                    _ => {
+                        error!("[overlay] ignoring tombstone at wrapper root: {path:?}");
+                        continue;
+                    }
+                };
+                self.register_mask(exe_dir.join(parent_rel));
+            } else {
+                let logical = NormalizedPath::new(exe_dir.join(&rel));
+                if !claimed.insert(logical.clone()) {
+                    error!(
+                        "[overlay] collision: {:?} already overlaid by an earlier wrapper, ignoring {:?}",
+                        logical, path
+                    );
+                    continue;
+                }
+                self.register(logical, path);
+            }
+        }
+    }
+
     pub fn try_remap(&self, path: &NormalizedPath) -> Option<PathBuf> {
         for mapping in &self.mappings {
             if let Some(remapped) = splice_path(path, &mapping.source, &mapping.target) {
@@ -50,6 +144,10 @@ impl PathRegistry {
             }
         }
         None
+    }
+
+    pub fn is_masked(&self, path: &NormalizedPath) -> bool {
+        self.masks.iter().any(|m| path.starts_with(m))
     }
 
     pub fn would_remap(&self, path: &NormalizedPath) -> bool {
@@ -92,6 +190,36 @@ mod tests {
         let path = NormalizedPath::new("C:\\Other\\file.txt");
         let result = registry.try_remap(&path);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_mask_matches_self_and_descendants() {
+        let mut registry = PathRegistry::new();
+        registry.register_mask("C:\\Game\\Mods\\CheatMod");
+
+        assert!(registry.is_masked(&NormalizedPath::new("C:\\Game\\Mods\\CheatMod")));
+        assert!(registry.is_masked(&NormalizedPath::new("C:\\Game\\Mods\\CheatMod\\Scripts\\main.lua")));
+        assert!(!registry.is_masked(&NormalizedPath::new("C:\\Game\\Mods\\OtherMod")));
+        assert!(!registry.is_masked(&NormalizedPath::new("C:\\Game\\Mods")));
+    }
+
+    #[test]
+    fn test_mask_independent_of_remap() {
+        let mut registry = PathRegistry::new();
+        registry.register("C:\\Game\\Mods", "D:\\MyMods");
+        registry.register_mask("C:\\Game\\Mods\\CheatMod");
+
+        // Callers must consult is_masked() first, try_remap is mask-unaware.
+        let masked = NormalizedPath::new("C:\\Game\\Mods\\CheatMod\\foo.lua");
+        assert!(registry.is_masked(&masked));
+        assert!(registry.try_remap(&masked).is_some());
+
+        let unmasked = NormalizedPath::new("C:\\Game\\Mods\\OtherMod\\foo.lua");
+        assert!(!registry.is_masked(&unmasked));
+        assert_eq!(
+            registry.try_remap(&unmasked),
+            Some(PathBuf::from("D:\\MyMods\\othermod\\foo.lua"))
+        );
     }
 
     #[test]

--- a/src/paths/splice.rs
+++ b/src/paths/splice.rs
@@ -8,6 +8,10 @@ pub fn remap_path(path: &NormalizedPath) -> Option<PathBuf> {
     PATH_REGISTRY.get().and_then(|registry| registry.try_remap(path))
 }
 
+pub fn is_masked(path: &NormalizedPath) -> bool {
+    PATH_REGISTRY.get().is_some_and(|registry| registry.is_masked(path))
+}
+
 /// Splice a path from one root onto another.
 /// Returns the remapped path if `path` starts with `source_root`, otherwise None.
 pub fn splice_path(
@@ -20,7 +24,12 @@ pub fn splice_path(
     }
 
     let relative = path.strip_prefix(source_root)?;
-    let result = target_root.to_path_buf().join(relative);
+    // Avoid Path::join(""): Win32 CreateFile rejects file paths ending in `\`.
+    let result = if relative.as_os_str().is_empty() {
+        target_root.to_path_buf()
+    } else {
+        target_root.to_path_buf().join(relative)
+    };
 
     Some(result)
 }
@@ -83,6 +92,19 @@ mod tests {
     }
 
     #[test]
+    fn test_splice_path_exact_match_no_trailing_separator() {
+        // PathBuf component-equality hides trailing `\`, check raw bytes.
+        let path = NormalizedPath::new("C:\\Game\\Win64\\UE4SS-settings.ini");
+        let source = NormalizedPath::new("C:\\Game\\Win64\\UE4SS-settings.ini");
+        let target = NormalizedPath::new("D:\\overlay\\Wrap\\UE4SS-settings.ini");
+
+        let result = splice_path(&path, &source, &target).unwrap();
+        let bytes = result.as_os_str().to_string_lossy();
+        assert!(!bytes.ends_with('\\'), "remap target must not end with backslash, got {bytes:?}");
+        assert_eq!(bytes, "D:\\overlay\\Wrap\\UE4SS-settings.ini");
+    }
+
+    #[test]
     fn test_splice_path_case_insensitive() {
         let path = NormalizedPath::new("C:\\GAME\\MODS\\test.lua");
         let source = NormalizedPath::new("c:\\game\\mods");
@@ -142,7 +164,7 @@ mod tests {
         // Simulating EXE_DIR.join("Mods") where EXE_DIR comes from env::current_exe().parent()
         let exe_dir = PathBuf::from(r"D:\Games\steamapps\common\ASTRONEER\Astro\Binaries\Win64");
         let source = NormalizedPath::new(exe_dir.join("Mods"));
-        
+
         let path = NormalizedPath::new(r"D:\Games\steamapps\common\ASTRONEER\Astro\Binaries\Win64\Mods\AutoIntegrator\dlls\main.dll");
         let target = NormalizedPath::new(r"C:\Users\Test\MyMods");
 
@@ -182,10 +204,10 @@ mod tests {
         println!("Path inner: {:?}", path.inner());
         println!("Source with trailing: {:?}", source_with_slash.inner());
         println!("Source without trailing: {:?}", source_without.inner());
-        
+
         let result1 = splice_path(&path, &source_with_slash, &target);
         let result2 = splice_path(&path, &source_without, &target);
-        
+
         println!("Result with trailing slash source: {:?}", result1);
         println!("Result without trailing slash source: {:?}", result2);
     }
@@ -194,22 +216,22 @@ mod tests {
     #[test]
     fn test_lib_rs_registration_scenario() {
         use std::path::PathBuf;
-        
+
         // Simulate EXE_DIR from env::current_exe().parent()
         let exe_dir = PathBuf::from(r"D:\Games\steamapps\common\ASTRONEER\Astro\Binaries\Win64");
-        
+
         // This is how lib.rs registers: registry.register(EXE_DIR.join("Mods"), ...)
         let source = NormalizedPath::new(exe_dir.join("Mods"));
         let target = NormalizedPath::new(r"C:\Users\Test\MyMods");
-        
+
         println!("Source (from join): {:?}", source.inner());
-        
+
         // This is the path UE4SS would try to access
         let dll_path = NormalizedPath::new(r"D:\Games\steamapps\common\ASTRONEER\Astro\Binaries\Win64\Mods\AutoIntegrator\dlls\main.dll");
-        
+
         println!("DLL path: {:?}", dll_path.inner());
         println!("starts_with: {}", dll_path.starts_with(&source));
-        
+
         let result = splice_path(&dll_path, &source, &target);
         assert!(result.is_some(), "DLL path should be remapped! Got: {:?}", result);
         println!("Remapped: {:?}", result);


### PR DESCRIPTION
Communities can ship thin wrapper packages that overlay onto Win64/ without forking the generic shimloader. Each file under `--overlay-dir/<wrapper>/<rel>` becomes an `EXE_DIR/<rel>` mapping, registered ahead of mod/pak/cfg so first-match-wins puts wrapper files on top. A `.shim-removed` file registers its parent as masked, which short-circuits the file detours and filters the dir out of `FindFirstFile`/`FindNextFile` enumeration. Multi-wrapper collisions log an error, alphabetically-first wins.

Also fixes `splice_path` appending a trailing `\` on exact-match remaps (`target.join("")`), which Win32 `CreateFile` rejects. Only mattered once individual files became remap targets.

r2modman needs a matching PR for the `shimloader/overlay` install rule and the new launch arg.