### PR TITLE
Publish resolved paths via SHIMLOADER_* env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ unreal-shimloader is controlled via the following arguments:
 `--overlay-dir`: The path of a directory containing one or more wrapper-package subdirectories. Each wrapper's file tree is overlaid onto `GAME/Binaries/Win64/`.
 - Maps to `GAME/Binaries/Win64`
 
+### Environment variables
+
+After parsing its command line, shimloader publishes the resolved paths into the process environment so overlay-loaded wrapper DLLs can read them without re-parsing the (sanitized) command line:
+
+- `SHIMLOADER_MOD_DIR`: value of `--mod-dir`
+- `SHIMLOADER_PAK_DIR`: value of `--pak-dir`
+- `SHIMLOADER_CFG_DIR`: value of `--cfg-dir`
+- `SHIMLOADER_OVERLAY_DIR`: value of `--overlay-dir`, only set when the switch is provided
+
+These are set before `ue4ss.dll` is loaded, so anything pulled in via the overlay can read them from `DllMain` with `GetEnvironmentVariableW`.
+
 ### Thanks
 
 A special thanks goes out to modestimpala who has contributed greatly to improving this project.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,17 @@ unsafe fn shim_init() {
         let _ = fs::create_dir_all(dir);
     }
 
+    // Publish resolved paths so overlay-loaded wrapper DLLs can discover
+    // them. The shimloader command line is sanitized before the rest of the
+    // process sees it, so a wrapper has no other portable way to recover
+    // these without parsing logs or walking the PEB.
+    env::set_var("SHIMLOADER_MOD_DIR", ue4ss_mods.as_ref());
+    env::set_var("SHIMLOADER_PAK_DIR", bp_mods.as_ref());
+    env::set_var("SHIMLOADER_CFG_DIR", config_dir.as_ref());
+    if let Some(overlay) = overlay_dir.as_ref() {
+        env::set_var("SHIMLOADER_OVERLAY_DIR", overlay);
+    }
+
     // Build the path registry with all virtual directory mappings.
     let mut registry = PathRegistry::new();
 


### PR DESCRIPTION
Right now overlay-loaded wrappers can't see `--mod-dir`/`--pak-dir`/`--cfg-dir`/` --overlay-dir` because GetCommandLineW is detoured to strip them. The only workarounds are parsing `shimloader-txt.log` or walking the PEB directly, both not preferable. 

This PR sets them in the env before loading UE4SS so wrappers can read them with GetEnvironmentVariableW from DllMain. 
They're process-local and skipped on vanilla path.

Tested on Unreal Engine 4.27.2 Voices of the Void a09l, confirmed env vars visible to test wrapper. 

```
[2026-05-07 06:33:18.405 INFO src\lib.rs:158] env SHIMLOADER_MOD_DIR = "C:\\Users\\moddy\\AppData\\Roaming\\r2modmanPlus-local\\VotV\\profiles\\09\\shimloader\\mod"
[2026-05-07 06:33:18.405 INFO src\lib.rs:158] env SHIMLOADER_PAK_DIR = "C:\\Users\\moddy\\AppData\\Roaming\\r2modmanPlus-local\\VotV\\profiles\\09\\shimloader\\pak"
[2026-05-07 06:33:18.405 INFO src\lib.rs:158] env SHIMLOADER_CFG_DIR = "C:\\Users\\moddy\\AppData\\Roaming\\r2modmanPlus-local\\VotV\\profiles\\09\\shimloader\\cfg"
[2026-05-07 06:33:18.405 INFO src\lib.rs:158] env SHIMLOADER_OVERLAY_DIR = "C:\\Users\\moddy\\AppData\\Roaming\\r2modmanPlus-local\\VotV\\profiles\\09\\shimloader\\overlay"
```